### PR TITLE
Add checkbox checked state validation

### DIFF
--- a/cypress/e2e/exercise3/verifyCheckboxState.cy.js
+++ b/cypress/e2e/exercise3/verifyCheckboxState.cy.js
@@ -1,0 +1,22 @@
+// Test Case: Verify Checkbox State
+// This test verifies if a specific checkbox is checked.
+
+describe("Verify Checkbox State", () => {
+  it("Verify if a specific checkbox is checked", () => {
+    // Step 1: Navigate to the home page(using the base url defined in cypress.config.js)
+    cy.visit("/");
+    // Step 2: Click on the Exercise 3 tab
+    cy.get('[role="tab"]')
+      .contains("Exercise 3 - Checkbox Verification")
+      .click();
+    // Step 3: Find the specific checkbox and verify if it is checked
+    cy.get('div[data-cy="test-grid-3"]')
+      .find("div.grid-item")
+      .eq(1)
+      .find("div.item-content")
+      .find("p")
+      .contains("Test2")
+      .siblings("input")
+      .should("be.checked");
+  });
+});


### PR DESCRIPTION
This PR adds a Cypress test to validate the state of a checkbox element, checking if it is marked as checked.

Changes:
- Added Cypress tests under the cypress/e2e/exercise3/ folder to:
1. Find the checkbox within test-grid-3
2. Ensure it's within the item-content div
3. Verify it's associated with a paragraph containing "Test2"
4. Check if it's checked

How to test:
- Run npx cypress open
- Execute the tests in the file verifyCheckboxState.cy.js