### PR TITLE
Intercepts an API call

### DIFF
--- a/cypress/e2e/exercise7/apiInterception.cy.js
+++ b/cypress/e2e/exercise7/apiInterception.cy.js
@@ -1,0 +1,25 @@
+// Test Case: API Interception
+
+describe("API Interception", () => {
+  it("POST", () => {
+    //Step 1: Monitor the POST request to the jsonplaceholder API
+    cy.intercept("POST", "https://jsonplaceholder.typicode.com/posts").as("postRequest")
+
+    //Step 2 :Simulate a POST request with a mock payload
+    cy.request({
+      method: "POST",
+      url: "https://jsonplaceholder.typicode.com/posts",
+      body: {
+        title: "Product Added",
+        body: "Added product to cart",
+        userId: 1,
+      },
+    }).then((response) => {
+      //// Assertions to check if the response is as expected
+      expect(response.body).to.have.property("id").to.be.a("number").eq(101);
+      expect(response.body).to.have.property("title");
+      expect(response.body).to.have.property("body");
+      expect(response.body).to.have.property("userId");
+    });
+  });
+});


### PR DESCRIPTION
This PR adds Cypress tests that intercept an API call and verify both request and response using callback functions.

Changes:
- Added Cypress tests under the cypress/e2e/exercise7/ folder to:
1. Intercept POST request to jsonplaceholder.typicode.com/posts

How to test:
- Run npx cypress open
- Execute the tests in the file apiInterception.cy.js